### PR TITLE
a11y: role attribute on portal message

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 3.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added role attribute for portal message with diazo [nzambello]
 
 
 3.0.10 (2018-12-20)

--- a/src/design/plone/theme/theme/backend.xml
+++ b/src/design/plone/theme/theme/backend.xml
@@ -197,4 +197,15 @@
   </before>
   <drop css:content="#content .portalMessage" / -->
 
+  <replace content="//*[@class[contains(., 'portalMessage')]]">
+    <xsl:variable name="status">
+      <xsl:if test="@class[contains(., 'info')]">status</xsl:if>
+      <xsl:if test="@class[contains(., 'success')]">status</xsl:if>
+      <xsl:if test="@class[contains(., 'warning')]">polite</xsl:if>
+      <xsl:if test="@class[contains(., 'error')]">polite</xsl:if>
+    </xsl:variable>
+    <div role="{$status}"><xsl:copy-of select="attribute::*" />
+      <xsl:apply-templates select="./node()" />
+    </div>
+  </replace>
 </rules>

--- a/src/design/plone/theme/theme/designplonetheme_rules.xml
+++ b/src/design/plone/theme/theme/designplonetheme_rules.xml
@@ -73,6 +73,17 @@
   </replace>
   <drop css:content="#portal-languageselector" />
 
+  <replace content="//*[@class[contains(., 'portalMessage')]]">
+    <xsl:variable name="status">
+      <xsl:if test="@class[contains(., 'info')]">status</xsl:if>
+      <xsl:if test="@class[contains(., 'success')]">status</xsl:if>
+      <xsl:if test="@class[contains(., 'warning')]">alert</xsl:if>
+      <xsl:if test="@class[contains(., 'error')]">alert</xsl:if>
+    </xsl:variable>
+    <div role="{$status}"><xsl:copy-of select="attribute::*" />
+      <xsl:apply-templates select="./node()" />
+    </div>
+  </replace>
 
   <!-- sposto le colonne dentro ad un container -->
   <replace css:content="#portal-column-content">

--- a/src/design/plone/theme/theme/designplonetheme_rules.xml
+++ b/src/design/plone/theme/theme/designplonetheme_rules.xml
@@ -77,8 +77,8 @@
     <xsl:variable name="status">
       <xsl:if test="@class[contains(., 'info')]">status</xsl:if>
       <xsl:if test="@class[contains(., 'success')]">status</xsl:if>
-      <xsl:if test="@class[contains(., 'warning')]">alert</xsl:if>
-      <xsl:if test="@class[contains(., 'error')]">alert</xsl:if>
+      <xsl:if test="@class[contains(., 'warning')]">polite</xsl:if>
+      <xsl:if test="@class[contains(., 'error')]">polite</xsl:if>
     </xsl:variable>
     <div role="{$status}"><xsl:copy-of select="attribute::*" />
       <xsl:apply-templates select="./node()" />


### PR DESCRIPTION
Il portal message manca dell'attributo `role`.
In questo modo lo aggiungiamo verso molti casi (non tutti perchè ci sono cose caricate via js), soprattutto in frontend.