### PR TITLE
plone-logged-in override is registered only if Plone version is < 5.1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 
-3.0.11 (unreleased)
+3.1.0 (unreleased)
 -------------------
 
 - a11y: added role attribute for portal message with diazo [nzambello]
@@ -12,6 +12,8 @@ Changelog
 Compatibility with Plone 5.1.4:
 
 - Updated styles for pagination, improved accessibility and responsiveness [nzambello]
+- `plone-logged-in` override is registered only if Plone version is < 5.1.4
+  [cekk]
 
 
 3.0.10 (2018-12-20)

--- a/src/design/plone/theme/profiles/default/metadata.xml
+++ b/src/design/plone/theme/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1200</version>
+  <version>1300</version>
   <dependencies>
     <dependency>profile-collective.tiles.collection:default</dependency>
     <dependency>profile-collective.tiles.advancedstatic:default</dependency>

--- a/src/design/plone/theme/profiles/default/registry.xml
+++ b/src/design/plone/theme/profiles/default/registry.xml
@@ -159,10 +159,4 @@
     </value>
   </record>
 
-  <records prefix="plone.bundles/plone-logged-in"
-           interface='Products.CMFPlone.interfaces.IBundleRegistry'
-           purge="false">
-    <value key="jscompilation">++plone++design.plone.theme/plone-logged-in-compiled.min.js</value>
-  </records>
-
 </registry>

--- a/src/design/plone/theme/setuphandlers.py
+++ b/src/design/plone/theme/setuphandlers.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
+from pkg_resources import parse_version
 from plone import api
 from Products.CMFPlone.interfaces import INonInstallable
 from Products.MimetypesRegistry import MimeTypeItem
-from redturtle.tiles.management.interfaces import IRedturtleTilesManagementSettings  # noqa
+from redturtle.tiles.management.interfaces import (
+    IRedturtleTilesManagementSettings,
+)
 from zope.interface import implementer
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 
 @implementer(INonInstallable)
 class HiddenProfiles(object):
-
     def getNonInstallableProfiles(self):
         """Hide uninstall profile from site-creation and quickinstaller"""
-        return [
-            'design.plone.theme:uninstall',
-        ]
+        return ['design.plone.theme:uninstall']
 
 
 def post_install(context):
@@ -22,6 +24,7 @@ def post_install(context):
     add_advancedstatic_styles(context)
     filter_tiles(context)
     fix_mimetype_icons(context)
+    override_plone_logged_in_js(context)
 
 
 def uninstall(context):
@@ -35,17 +38,18 @@ def filter_tiles(context):
         u'collective.tiles.collection',
         u'collective.tiles.advancedstatic',
         u'plone.app.standardtiles.existingcontent',
-        u'plone.app.standardtiles.navigation'
+        u'plone.app.standardtiles.navigation',
     ]
     api.portal.set_registry_record(
-        'enabled_tiles',
-        starting_tiles,
-        IRedturtleTilesManagementSettings)
+        'enabled_tiles', starting_tiles, IRedturtleTilesManagementSettings
+    )
 
 
 def add_advancedstatic_styles(context):
-    NEW_STYLES = (u'portletStaticNavigation|stile menu di navigazione',
-                  u'PagesTileStatic|stile landing page aree tematiche')
+    NEW_STYLES = (
+        u'portletStaticNavigation|stile menu di navigazione',
+        u'PagesTileStatic|stile landing page aree tematiche',
+    )
 
     STYLES = api.portal.get_registry_record(
         'collective.tiles.advancedstatic.css_styles'
@@ -57,8 +61,7 @@ def add_advancedstatic_styles(context):
             STYLES += (s,)
 
     api.portal.set_registry_record(
-        'collective.tiles.advancedstatic.css_styles',
-        STYLES
+        'collective.tiles.advancedstatic.css_styles', STYLES
     )
 
 
@@ -72,3 +75,19 @@ def revert_mimetype_icons(context):
     mtr = api.portal.get_tool(name='mimetypes_registry')
     for mimetype in mtr.extensions.values():
         mimetype.icon_path = MimeTypeItem._old_guess_icon_path(mimetype)
+
+
+def override_plone_logged_in_js(context):
+    """
+    This is needed only in < 5.1.4 Plone versions.
+    The custom js has a fix for the toolbar accessibility that has been
+    merged in 5.1.4.
+    """
+    plone_version = api.env.plone_version()
+    if parse_version(plone_version) < parse_version('5.1.4'):
+        registry = getUtility(IRegistry)
+        reg_key = 'plone.bundles/plone-logged-in.jscompilation'
+        registry[
+            reg_key
+        ] = '++plone++design.plone.theme/plone-logged-in-compiled.min.js'
+

--- a/src/design/plone/theme/upgrades/configure.zcml
+++ b/src/design/plone/theme/upgrades/configure.zcml
@@ -20,5 +20,13 @@
     description="Added a field in theme controlpanel"
     handler=".upgrades.import_records_registry"
     />
+  <genericsetup:upgradeStep
+    source="1200"
+    destination="1300"
+    profile="design.plone.theme:default"
+    title="Plone 5.1.4 compatibility"
+    description=""
+    handler=".upgrades.to_1300"
+    />
 
 </configure>

--- a/src/design/plone/theme/upgrades/upgrades.py
+++ b/src/design/plone/theme/upgrades/upgrades.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from design.plone.theme import logger
-from design.plone.theme.controlpanel.interfaces import IDesignPloneThemeSettings  # noqa
+from design.plone.theme.controlpanel.interfaces import (
+    IDesignPloneThemeSettings,
+)  # noqa
+from pkg_resources import parse_version
 from plone import api
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
@@ -11,56 +14,66 @@ DEFAULT_PROFILE = 'profile-design.plone.theme:default'
 
 def import_registry(registry_id, dependencies=False):
     setup_tool = api.portal.get_tool('portal_setup')
-    setup_tool.runImportStepFromProfile(DEFAULT_PROFILE, registry_id,
-                                        run_dependencies=dependencies)
+    setup_tool.runImportStepFromProfile(
+        DEFAULT_PROFILE, registry_id, run_dependencies=dependencies
+    )
 
 
 def import_css_registry(context):
     'Import CSS registry configuration'
-    logger.info('Importing CSS registry configuration for ' +
-                'design.plone.theme')
+    logger.info(
+        'Importing CSS registry configuration for ' + 'design.plone.theme'
+    )
     import_registry('cssregistry')
 
 
 def import_js_registry(context):
     'Import js registry configuration'
-    logger.info('Importing js registry configuration for ' +
-                'design.plone.theme')
+    logger.info(
+        'Importing js registry configuration for ' + 'design.plone.theme'
+    )
     import_registry('jsregistry')
 
 
 def import_actions_registry(context):
     'Import actions registry configuration'
-    logger.info('Importing actions registry configuration for ' +
-                'design.plone.theme')
+    logger.info(
+        'Importing actions registry configuration for ' + 'design.plone.theme'
+    )
     import_registry('actions')
 
 
 def import_types_registry(context):
     'Import types registry configuration'
-    logger.info('Importing types registry configuration for ' +
-                'design.plone.theme')
+    logger.info(
+        'Importing types registry configuration for ' + 'design.plone.theme'
+    )
     import_registry('typeinfo')
 
 
 def import_viewlets_registry(context):
     'Import viewlets registry configuration'
-    logger.info('Importing viewlets registry configuration for ' +
-                'design.plone.theme')
+    logger.info(
+        'Importing viewlets registry configuration for ' + 'design.plone.theme'
+    )
     import_registry('viewlets')
 
 
 def import_properties_registry(context):
     'Import properties registry configuration'
-    logger.info('Importing properties registry configuration for ' +
-                'design.plone.theme')
+    logger.info(
+        'Importing properties registry configuration for '
+        + 'design.plone.theme'
+    )
     import_registry('propertiestool')
 
 
 def import_records_registry(context):
     'Import records and settings'
-    logger.info('Importing records and settings configuration for' +
-                'design.plone.theme')
+    logger.info(
+        'Importing records and settings configuration for'
+        + 'design.plone.theme'
+    )
     import_registry('plone.app.registry')
 
 
@@ -68,15 +81,16 @@ def clean_follow_us_fields(context):
     remove_fields = [
         'header_facebook_link',
         'header_youtube_link',
-        'header_twitter_link'
+        'header_twitter_link',
     ]
     registry = getUtility(IRegistry)
     for field in remove_fields:
         try:
-            del registry.records['{0}.{1}'.format(
-                IDesignPloneThemeSettings.__identifier__,
-                field
-            )]
+            del registry.records[
+                '{0}.{1}'.format(
+                    IDesignPloneThemeSettings.__identifier__, field
+                )
+            ]
         except KeyError:
             # entry not present in registry
             continue
@@ -85,18 +99,30 @@ def clean_follow_us_fields(context):
 
 def fix_default_header_links(context):
     header_link_label = api.portal.get_registry_record(
-        'header_link_label',
-        interface=IDesignPloneThemeSettings)
+        'header_link_label', interface=IDesignPloneThemeSettings
+    )
     header_link_url = api.portal.get_registry_record(
-        'header_link_url',
-        interface=IDesignPloneThemeSettings)
+        'header_link_url', interface=IDesignPloneThemeSettings
+    )
     if not header_link_label:
         api.portal.set_registry_record(
             'header_link_label',
             u'Governo Italiano',
-            interface=IDesignPloneThemeSettings)
+            interface=IDesignPloneThemeSettings,
+        )
     if not header_link_url:
         api.portal.set_registry_record(
             'header_link_url',
             'http://www.governo.it',
-            interface=IDesignPloneThemeSettings)
+            interface=IDesignPloneThemeSettings,
+        )
+
+
+def to_1300(context):
+    """ """
+    plone_version = api.env.plone_version()
+    if parse_version(plone_version) >= parse_version('5.1.4'):
+        # remove custom js
+        registry = getUtility(IRegistry)
+        reg_key = 'plone.bundles/plone-logged-in.jscompilation'
+        registry[reg_key] = '++plone++static/plone-logged-in-compiled.min.js'


### PR DESCRIPTION
This override fixes an old problem with toolbar that has been merged in newer versions of Products.CMFPlone.

I added an upgrade-step that removes this override if Plone version is > 5.1.4.
setuphandler.py add the override if the Plone version is < 5.1.4