### PR TITLE
Photogallery tile collection: opening external links in new tab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Photogallery tile collection: opening external links in new tab [nzambello]
 
 
 4.0.0 (2020-02-13)

--- a/src/design/plone/theme/browser/templates/photogallery_renderer.pt
+++ b/src/design/plone/theme/browser/templates/photogallery_renderer.pt
@@ -33,12 +33,15 @@
                                           item_wf_state obj/review_state;
                                           item_wf_state_class python:'state-' + plone_view.normalizeString(item_wf_state);
                                           item_type obj/portal_type;
-                                          item_type_class python:'contenttype-' + plone_view.normalizeString(item_type);"
+                                          item_type_class python:'contenttype-' + plone_view.normalizeString(item_type);
+                                          is_external_link python: helper_view.is_external_link(obj);"
                               tal:attributes="class python: 'colonna-1-di-3 ' + (oddrow and 'collectionItem even' or 'collectionItem odd')">
                               <div class="collectionItemWrapper">
                                   <a href="#"
                                      tal:attributes="href itemUrl;
                                                      class string:tile $item_type_class $item_wf_state_class;
+                                                     target python: is_external_link and '_blank' or None;
+                                                     rel python: is_external_link and 'noopener noreferrer' or None;
                                                      title obj/Description">
                                       <div class="collectionItemImage">
                                           <!-- if obj is None, it will break calling getObject() on it, but if the collection is empty this won't be rendered by collective.tiles.collection -->

--- a/src/design/plone/theme/browser/tile_collection_renderers.py
+++ b/src/design/plone/theme/browser/tile_collection_renderers.py
@@ -84,6 +84,17 @@ class HelpersView(BrowserView):
             'comments': conversation.total_comments()
         }
 
+    def is_external_link(self, item):
+        # accepts a Link object
+        obj = item.getObject()
+        remoteUrl = getattr(obj, 'remoteUrl', None)
+
+        if remoteUrl:
+            # so it's a Link
+            return not remoteUrl.startswith('${portal_url}')
+
+        return False
+
 
 @implementer(ICollectionTileRenderer)
 class SightsView(BrowserView):

--- a/src/design/plone/theme/browser/tile_collection_renderers.py
+++ b/src/design/plone/theme/browser/tile_collection_renderers.py
@@ -91,7 +91,9 @@ class HelpersView(BrowserView):
 
         if remoteUrl:
             # so it's a Link
-            return not remoteUrl.startswith('${portal_url}')
+            return not remoteUrl.startswith(
+                "${portal_url}"
+            ) and not remoteUrl.startswith("${navigation_root_url}")
 
         return False
 


### PR DESCRIPTION
Fixes #86.

Aggiunto metodo nella vista helper per le tile collection che controlla se, in un oggetto Link, l'URL è esterno o interno al sito.
Se è un link esterno, allora aggiunge ```target="_blank"``` e ```rel="noopener noreferrer"```.